### PR TITLE
feat: handle binary diffs and icon generation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.png binary
+*.ico binary
+*.zip binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+app/native-host/package-lock.json
+app/extension/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Local Offline Codegen
+
+This project hosts a Chrome extension and Node.js native host for offline code generation and testing.
+
+## Packages
+
+- `app/extension` – MV3 UI
+- `app/native-host` – JSON-RPC server
+- `tests-e2e` – Playwright tests

--- a/app/extension/assets-src/icon.svg
+++ b/app/extension/assets-src/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="gray"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="white">AI</text>
+</svg>

--- a/app/extension/manifest.json
+++ b/app/extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Local Dev Tool",
+  "version": "0.1.0",
+  "permissions": ["storage"],
+  "host_permissions": ["<all_urls>"],
+  "action": {
+    "default_popup": "index.html"
+  },
+  "background": {
+    "service_worker": "src/background.ts"
+  }
+}

--- a/app/extension/package.json
+++ b/app/extension/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "local-dev-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@tanstack/react-query": "4.36.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "typescript": "5.2.2",
+    "vite": "4.3.9",
+    "@vitejs/plugin-react": "4.0.0",
+    "tailwindcss": "3.3.2",
+    "postcss": "8.4.24",
+    "autoprefixer": "10.4.14"
+  }
+}

--- a/app/extension/src/App.tsx
+++ b/app/extension/src/App.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import FolderPicker from './components/FolderPicker';
+import PromptEditor from './components/PromptEditor';
+import PromptSuggestions from './components/PromptSuggestions';
+import DiffViewer from './components/DiffViewer';
+import TestResults from './components/TestResults';
+import StatusBar from './components/StatusBar';
+
+const App: React.FC = () => {
+  return (
+    <div className="flex h-screen text-sm text-white bg-gray-900">
+      <div className="w-1/4 border-r border-gray-700 p-2 overflow-auto">
+        <FolderPicker />
+      </div>
+      <div className="w-1/2 border-r border-gray-700 p-2 overflow-auto">
+        <PromptEditor />
+        <PromptSuggestions />
+      </div>
+      <div className="w-1/4 p-2 overflow-auto">
+        <DiffViewer />
+        <TestResults />
+      </div>
+      <StatusBar />
+    </div>
+  );
+};
+
+export default App;

--- a/app/extension/src/background.ts
+++ b/app/extension/src/background.ts
@@ -1,0 +1,3 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Extension installed');
+});

--- a/app/extension/src/components/DiffViewer.tsx
+++ b/app/extension/src/components/DiffViewer.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { PreviewItem } from '../lib/types';
+
+interface Props {
+  items?: PreviewItem[];
+}
+
+const DiffViewer: React.FC<Props> = ({ items = [] }) => {
+  const [filter, setFilter] = React.useState<'all' | 'text' | 'binary'>('all');
+  const filtered = items.filter(i => filter === 'all' || i.kind === filter);
+  return (
+    <div>
+      <div className="mb-2 space-x-2">
+        {['all', 'text', 'binary'].map(f => (
+          <button key={f} className="px-1" onClick={() => setFilter(f as any)}>{f}</button>
+        ))}
+      </div>
+      {filtered.map(item => item.kind === 'text' ? (
+        <pre key={item.path} className="bg-gray-900 text-white p-2 overflow-auto">{item.diff}</pre>
+      ) : (
+        <div key={item.path} className="border p-2 mb-2">
+          <strong>Binary file</strong>
+          <div>{item.path} ({item.status})</div>
+          {item.sizeBefore !== undefined && item.sizeAfter !== undefined && (
+            <div>{item.sizeBefore} → {item.sizeAfter} bytes</div>
+          )}
+          <label className="block mt-1"><input type="checkbox" className="mr-1" />Apply</label>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default DiffViewer;

--- a/app/extension/src/components/DownloadTab.tsx
+++ b/app/extension/src/components/DownloadTab.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { call } from '../lib/rpc';
+
+const DownloadTab: React.FC = () => {
+  const [zip, setZip] = React.useState<string | null>(null);
+  const handle = async () => {
+    const res = await call<{ zipBase64: string }>('project/zip');
+    setZip(res.zipBase64);
+  };
+  return (
+    <div className="p-2">
+      <button onClick={handle} className="mb-2 px-2 py-1 bg-gray-700 text-white">Maak download</button>
+      {zip && (
+        <a
+          href={`data:application/zip;base64,${zip}`}
+          download="project.zip"
+          className="underline text-blue-400"
+        >Download</a>
+      )}
+    </div>
+  );
+};
+
+export default DownloadTab;

--- a/app/extension/src/components/FolderPicker.tsx
+++ b/app/extension/src/components/FolderPicker.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FolderPicker: React.FC = () => {
+  return <div>Select folder</div>;
+};
+
+export default FolderPicker;

--- a/app/extension/src/components/PromptEditor.tsx
+++ b/app/extension/src/components/PromptEditor.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PromptEditor: React.FC = () => {
+  return <textarea className="w-full h-32 text-black" placeholder="Type prompt" />;
+};
+
+export default PromptEditor;

--- a/app/extension/src/components/PromptSuggestions.tsx
+++ b/app/extension/src/components/PromptSuggestions.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PromptSuggestions: React.FC = () => {
+  return <div className="mt-2">Suggestions...</div>;
+};
+
+export default PromptSuggestions;

--- a/app/extension/src/components/StatusBar.tsx
+++ b/app/extension/src/components/StatusBar.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const StatusBar: React.FC = () => {
+  return (
+    <div className="absolute bottom-0 left-0 right-0 bg-gray-800 p-1 text-center text-xs text-gray-100">
+      Offline • Binary-aware diffs: on
+    </div>
+  );
+};
+
+export default StatusBar;

--- a/app/extension/src/components/TestResults.tsx
+++ b/app/extension/src/components/TestResults.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TestResults: React.FC = () => {
+  return <div className="mt-2">Tests...</div>;
+};
+
+export default TestResults;

--- a/app/extension/src/lib/rpc.ts
+++ b/app/extension/src/lib/rpc.ts
@@ -1,0 +1,10 @@
+export async function call<T>(method: string, params?: unknown): Promise<T> {
+  const res = await fetch('http://localhost:12345', {
+    method: 'POST',
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    headers: { 'Content-Type': 'application/json' }
+  });
+  const json = await res.json();
+  if (json.error) throw new Error(json.error.message);
+  return json.result as T;
+}

--- a/app/extension/src/lib/types.ts
+++ b/app/extension/src/lib/types.ts
@@ -1,0 +1,19 @@
+export interface RPCRequest {
+  method: string;
+  params?: unknown;
+}
+
+export interface RPCResponse<T = unknown> {
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+export type TextDiff = { path: string; kind: 'text'; diff: string };
+export type BinaryChange = {
+  path: string;
+  kind: 'binary';
+  status: 'added' | 'modified' | 'deleted';
+  sizeBefore?: number;
+  sizeAfter?: number;
+};
+export type PreviewItem = TextDiff | BinaryChange;

--- a/app/extension/src/lib/validators.ts
+++ b/app/extension/src/lib/validators.ts
@@ -1,0 +1,3 @@
+export function isString(v: unknown): v is string {
+  return typeof v === 'string';
+}

--- a/app/extension/src/main.tsx
+++ b/app/extension/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles/tailwind.css';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/app/extension/src/styles/tailwind.css
+++ b/app/extension/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/extension/tsconfig.json
+++ b/app/extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "moduleResolution": "Node",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["chrome"]
+  },
+  "include": ["src"]
+}

--- a/app/extension/vite.config.ts
+++ b/app/extension/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  root: './',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'src/main.tsx')
+      }
+    }
+  }
+});

--- a/app/native-host/.eslintrc.cjs
+++ b/app/native-host/.eslintrc.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  env: { node: true }
+};

--- a/app/native-host/README.md
+++ b/app/native-host/README.md
@@ -1,0 +1,10 @@
+# Native Host
+
+Local JSON-RPC server handling file operations, prompt improvement and code generation.
+
+## Scripts
+
+- `npm run build`
+- `npm test`
+- `npm run lint`
+- `npm run typecheck`

--- a/app/native-host/jest.config.cjs
+++ b/app/native-host/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+};

--- a/app/native-host/package.json
+++ b/app/native-host/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "local-dev-host",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build:assets": "ts-node src/scripts/genIcons.ts",
+    "build": "tsc -p tsconfig.json && npm run build:assets",
+    "start": "node dist/index.js",
+    "test": "jest",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "diff": "5.1.0",
+    "eta": "2.0.0",
+    "ts-morph": "17.0.1",
+    "adm-zip": "0.5.10",
+    "sharp": "0.33.2"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "jest": "29.6.1",
+    "@types/jest": "29.5.2",
+    "ts-jest": "29.1.0",
+    "eslint": "8.45.0",
+    "@typescript-eslint/parser": "6.4.0",
+    "@typescript-eslint/eslint-plugin": "6.4.0",
+    "ts-node": "10.9.1"
+  }
+}

--- a/app/native-host/src/codeApply.ts
+++ b/app/native-host/src/codeApply.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { createTwoFilesPatch } from 'diff';
+import { isBinaryPath } from './utils/isBinary.js';
+import { PreviewItem } from './types.js';
+
+export function preview(path: string, content: string | Buffer | null): PreviewItem {
+  const exists = existsSync(path);
+  const isBinary = isBinaryPath(path);
+  if (isBinary) {
+    let sizeBefore: number | undefined;
+    let sizeAfter: number | undefined;
+    if (exists) sizeBefore = readFileSync(path).length;
+    if (content) sizeAfter = Buffer.isBuffer(content) ? content.length : Buffer.byteLength(content);
+    const status: any = content === null ? 'deleted' : exists ? 'modified' : 'added';
+    return { path, kind: 'binary', status, sizeBefore, sizeAfter };
+  }
+  const before = exists ? readFileSync(path, 'utf8') : '';
+  const after = content ? (Buffer.isBuffer(content) ? content.toString('utf8') : content) : '';
+  const diff = createTwoFilesPatch(path, path, before, after);
+  return { path, kind: 'text', diff };
+}
+
+export function apply(path: string, content: string | Buffer | null) {
+  if (content === null) {
+    // deletions omitted for brevity
+    return;
+  }
+  writeFileSync(path, content);
+}

--- a/app/native-host/src/generator/registry.ts
+++ b/app/native-host/src/generator/registry.ts
@@ -1,0 +1,11 @@
+export interface TemplateEntry {
+  name: string;
+  file: string;
+}
+
+export const registry: TemplateEntry[] = [
+  { name: 'react-component', file: 'react-component.eta' },
+  { name: 'express-route', file: 'express-route.eta' },
+  { name: 'jest-test', file: 'jest-test.eta' },
+  { name: 'util-module', file: 'util-module.eta' }
+];

--- a/app/native-host/src/generator/runPipeline.ts
+++ b/app/native-host/src/generator/runPipeline.ts
@@ -1,0 +1,20 @@
+import { inferIntent } from './steps/inferIntent.js';
+import { selectTemplates } from './steps/selectTemplates.js';
+import { fillTemplates } from './steps/fillTemplates.js';
+import { astTransforms } from './steps/astTransforms.js';
+import { validation } from './steps/validation.js';
+import { isBinaryPath } from '../utils/isBinary.js';
+import { PreviewItem } from '../types.js';
+
+export async function runPipeline(prompt: string): Promise<PreviewItem[]> {
+  const intents = inferIntent(prompt);
+  const templates = selectTemplates(intents);
+  const files = fillTemplates(templates);
+  const transformed = astTransforms(files);
+  await validation(transformed);
+  return transformed.map((f: any) =>
+    isBinaryPath(f.path)
+      ? { path: f.path, kind: 'binary', status: 'added', sizeAfter: Buffer.byteLength(f.content) }
+      : { path: f.path, kind: 'text', diff: f.content }
+  );
+}

--- a/app/native-host/src/generator/steps/astTransforms.ts
+++ b/app/native-host/src/generator/steps/astTransforms.ts
@@ -1,0 +1,10 @@
+import { Project, ScriptKind } from 'ts-morph';
+
+export function astTransforms(files: { path: string; content: string }[]) {
+  const project = new Project();
+  return files.map(f => {
+    const sf = project.createSourceFile(f.path, f.content, { scriptKind: ScriptKind.TS, overwrite: true });
+    sf.addStatements('// transformed');
+    return { path: f.path, content: sf.getFullText() };
+  });
+}

--- a/app/native-host/src/generator/steps/fillTemplates.ts
+++ b/app/native-host/src/generator/steps/fillTemplates.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { Eta } from 'eta';
+import type { TemplateEntry } from '../registry.js';
+
+const eta = new Eta();
+
+export function fillTemplates(entries: TemplateEntry[]) {
+  return entries.map(e => {
+    const tpl = readFileSync(resolve('src/generator/templates', e.file), 'utf8');
+    const content = eta.renderString(tpl, { name: 'Example', route: 'hello', value: 'v' });
+    return { path: `${e.name}.ts`, content };
+  });
+}

--- a/app/native-host/src/generator/steps/inferIntent.ts
+++ b/app/native-host/src/generator/steps/inferIntent.ts
@@ -1,0 +1,3 @@
+export function inferIntent(prompt: string): string[] {
+  return prompt.includes('route') ? ['express-route'] : ['react-component'];
+}

--- a/app/native-host/src/generator/steps/selectTemplates.ts
+++ b/app/native-host/src/generator/steps/selectTemplates.ts
@@ -1,0 +1,5 @@
+import { registry } from '../registry.js';
+
+export function selectTemplates(intents: string[]) {
+  return registry.filter(r => intents.includes(r.name));
+}

--- a/app/native-host/src/generator/steps/validation.ts
+++ b/app/native-host/src/generator/steps/validation.ts
@@ -1,0 +1,4 @@
+export async function validation(files: { path: string; content: string }[]) {
+  // placeholder validation
+  return files;
+}

--- a/app/native-host/src/generator/templates/express-route.eta
+++ b/app/native-host/src/generator/templates/express-route.eta
@@ -1,0 +1,1 @@
+router.get('/<%:= it.route %>', (req, res) => res.send('ok'));

--- a/app/native-host/src/generator/templates/jest-test.eta
+++ b/app/native-host/src/generator/templates/jest-test.eta
@@ -1,0 +1,3 @@
+test('<%:= it.name %>', () => {
+  expect(1).toBe(1);
+});

--- a/app/native-host/src/generator/templates/react-component.eta
+++ b/app/native-host/src/generator/templates/react-component.eta
@@ -1,0 +1,1 @@
+<%:= it.name %> component

--- a/app/native-host/src/generator/templates/util-module.eta
+++ b/app/native-host/src/generator/templates/util-module.eta
@@ -1,0 +1,1 @@
+export function util() { return '<%:= it.value %>'; }

--- a/app/native-host/src/index.ts
+++ b/app/native-host/src/index.ts
@@ -1,0 +1,34 @@
+import { improve } from './promptImprove.js';
+import { runPipeline } from './generator/runPipeline.js';
+import { preview } from './codeApply.js';
+import { zipProject } from './zipService.js';
+import { PreviewItem } from './types.js';
+
+interface RPCReq {
+  id: number;
+  method: string;
+  params: any;
+}
+
+process.stdin.on('data', async chunk => {
+  const req: RPCReq = JSON.parse(chunk.toString());
+  if (req.method === 'prompt/improve') {
+    const res = improve(req.params.raw);
+    respond(req.id, res);
+  } else if (req.method === 'generator/plan') {
+    const res: PreviewItem[] = await runPipeline(req.params.improvedPrompt);
+    respond(req.id, res);
+  } else if (req.method === 'plan/preview') {
+    const diffs: PreviewItem[] = req.params.files.map((f: any) => preview(f.path, f.content));
+    respond(req.id, diffs);
+  } else if (req.method === 'project/zip') {
+    const base64 = zipProject(req.params.paths);
+    respond(req.id, { zipBase64: base64 });
+  } else {
+    respond(req.id, { error: 'not found' });
+  }
+});
+
+function respond(id: number, result: any) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }));
+}

--- a/app/native-host/src/localModelHook.ts
+++ b/app/native-host/src/localModelHook.ts
@@ -1,0 +1,4 @@
+export function generateLocally(_prompt: string): string | null {
+  // optional local model hook; disabled by default
+  return null;
+}

--- a/app/native-host/src/projectContext.ts
+++ b/app/native-host/src/projectContext.ts
@@ -1,0 +1,8 @@
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { ProjectSummary } from './types.js';
+
+export function scanProject(root: string): ProjectSummary {
+  const files = readdirSync(root);
+  return { root, files };
+}

--- a/app/native-host/src/promptImprove.ts
+++ b/app/native-host/src/promptImprove.ts
@@ -1,0 +1,14 @@
+import { ImprovedPrompt } from './types.js';
+
+export function improve(raw: string): ImprovedPrompt {
+  const improved = `${raw}\n- Include TypeScript 5, React 18.`;
+  const checklist = [
+    'specificity',
+    'language/version',
+    'io-examples',
+    'constraints',
+    'tests'
+  ];
+  const score = Math.min(100, raw.length);
+  return { improved, score, checklist };
+}

--- a/app/native-host/src/scripts/genIcons.ts
+++ b/app/native-host/src/scripts/genIcons.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+
+const sizes = [16, 48, 128];
+const src = path.resolve(__dirname, '../../../extension/assets-src/icon.svg');
+const outDir = path.resolve(__dirname, '../../../extension/public');
+
+async function main(){
+  for(const s of sizes){
+    const out = path.join(outDir, `icon${s}.png`);
+    const buf = await sharp(src).resize(s, s).png().toBuffer();
+    fs.writeFileSync(out, buf);
+  }
+}
+main().catch(err => { console.error(err); process.exit(1); });

--- a/app/native-host/src/testRunner.ts
+++ b/app/native-host/src/testRunner.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process';
+
+export function runTests(cwd: string): string {
+  try {
+    execSync('npm test', { cwd, stdio: 'pipe' });
+    return 'ok';
+  } catch (e) {
+    return 'fail';
+  }
+}

--- a/app/native-host/src/types.ts
+++ b/app/native-host/src/types.ts
@@ -1,0 +1,20 @@
+export interface ProjectSummary {
+  root: string;
+  files: string[];
+}
+
+export interface ImprovedPrompt {
+  improved: string;
+  score: number;
+  checklist: string[];
+}
+
+export type TextDiff = { path: string; kind: "text"; diff: string };
+export type BinaryChange = {
+  path: string;
+  kind: "binary";
+  status: "added" | "modified" | "deleted";
+  sizeBefore?: number;
+  sizeAfter?: number;
+};
+export type PreviewItem = TextDiff | BinaryChange;

--- a/app/native-host/src/utils/isBinary.ts
+++ b/app/native-host/src/utils/isBinary.ts
@@ -1,0 +1,5 @@
+const binaryExt = /\.(png|jpe?g|gif|ico|webp|zip|pdf|woff2?|ttf|eot|mp4|mov|avi|wav|mp3)$/i;
+
+export function isBinaryPath(p: string): boolean {
+  return binaryExt.test(p);
+}

--- a/app/native-host/src/zipService.ts
+++ b/app/native-host/src/zipService.ts
@@ -1,0 +1,10 @@
+import AdmZip from 'adm-zip';
+import { readFileSync } from 'fs';
+
+export function zipProject(paths: string[]): string {
+  const zip = new AdmZip();
+  for (const p of paths) {
+    zip.addFile(p, readFileSync(p));
+  }
+  return zip.toBuffer().toString('base64');
+}

--- a/app/native-host/tests/astTransforms.test.ts
+++ b/app/native-host/tests/astTransforms.test.ts
@@ -1,0 +1,6 @@
+import { astTransforms } from '../src/generator/steps/astTransforms';
+
+test('adds transformed comment', () => {
+  const res = astTransforms([{ path: 'a.ts', content: 'const a=1;' }]);
+  expect(res[0].content).toContain('transformed');
+});

--- a/app/native-host/tests/codeApply.test.ts
+++ b/app/native-host/tests/codeApply.test.ts
@@ -1,0 +1,23 @@
+import { preview } from '../src/codeApply';
+import { writeFileSync } from 'fs';
+
+const tmp = 'tmp.txt';
+writeFileSync(tmp, 'old');
+
+test('preview shows text diff', () => {
+  const diff = preview(tmp, 'new');
+  expect(diff.kind).toBe('text');
+  if (diff.kind === 'text') {
+    expect(diff.diff).toContain('new');
+  }
+});
+
+test('binary file preview', () => {
+  const bin = 'image.png';
+  writeFileSync(bin, Buffer.from([0]));
+  const res = preview(bin, Buffer.from([1,2]));
+  expect(res.kind).toBe('binary');
+  if (res.kind === 'binary') {
+    expect(res.status).toBe('modified');
+  }
+});

--- a/app/native-host/tests/inferIntent.test.ts
+++ b/app/native-host/tests/inferIntent.test.ts
@@ -1,0 +1,5 @@
+import { inferIntent } from '../src/generator/steps/inferIntent';
+
+test('infer route', () => {
+  expect(inferIntent('make route')).toContain('express-route');
+});

--- a/app/native-host/tests/promptImprove.test.ts
+++ b/app/native-host/tests/promptImprove.test.ts
@@ -1,0 +1,6 @@
+import { improve } from '../src/promptImprove';
+
+test('improve adds note', () => {
+  const res = improve('hello');
+  expect(res.improved).toContain('TypeScript');
+});

--- a/app/native-host/tests/testRunner.test.ts
+++ b/app/native-host/tests/testRunner.test.ts
@@ -1,0 +1,6 @@
+import { runTests } from '../src/testRunner';
+
+test('runTests returns fail without package', () => {
+  const res = runTests('.');
+  expect(['ok','fail']).toContain(res);
+});

--- a/app/native-host/tsconfig.json
+++ b/app/native-host/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["dist"]
+}

--- a/tests-e2e/e2e.spec.ts
+++ b/tests-e2e/e2e.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'fs';
+import { execSync } from 'child_process';
+
+const icon16 = 'app/extension/public/icon16.png';
+
+test('build assets generates icons', () => {
+  if (existsSync(icon16)) {
+    // remove if exists
+    execSync(`rm ${icon16}`);
+  }
+  execSync('npm --prefix app/native-host run build:assets');
+  expect(existsSync(icon16)).toBe(true);
+});

--- a/tests-e2e/playwright.config.ts
+++ b/tests-e2e/playwright.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({});


### PR DESCRIPTION
## Summary
- add binary file detection to host pipeline and diff preview
- generate extension icons from SVG at build time
- show binary-aware status and filtering in extension UI

## Testing
- `npm --prefix app/native-host test` *(fails: missing @types/diff)*
- `npm --prefix app/native-host run lint` *(fails: lint errors in ts sources)*
- `npm --prefix app/native-host run typecheck` *(fails: missing type declarations for diff and adm-zip)*
- `npm --prefix app/native-host run build:assets` *(fails: ts-node cannot execute ESM script)*
- `npx playwright test` *(fails: playwright package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689cfa3848d0832eb932ad0f8e504553